### PR TITLE
feat(ui): add dark mode and redesign with green color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MarkItDown Browser - Convert Documents to Markdown</title>
+    <title>Stan's MarkItDown Converter</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { FileUpload } from './components/FileUpload'
 import { FileList } from './components/FileList'
 import { MarkdownPreview } from './components/MarkdownPreview'
@@ -17,6 +17,22 @@ function App() {
   const [files, setFiles] = useState<FileResult[]>([])
   const [selectedFileIndex, setSelectedFileIndex] = useState<number | null>(null)
   const [converter] = useState(() => new MarkItDown())
+  const [darkMode, setDarkMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+    return false
+  })
+
+  // Handle dark mode class on document
+  useEffect(() => {
+    const root = window.document.documentElement
+    if (darkMode) {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }, [darkMode])
 
   const handleFilesSelected = async (selectedFiles: File[]) => {
     const newFiles: FileResult[] = selectedFiles.map(file => ({
@@ -72,20 +88,58 @@ function App() {
   const selectedFile = selectedFileIndex !== null ? files[selectedFileIndex] : null
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b">
+    <div className="min-h-screen flex flex-col">
+      {/* Header with gradient accent */}
+      <header className="relative border-b bg-card/80 backdrop-blur-sm">
+        <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent" />
         <div className="container mx-auto px-4 py-6">
-          <h1 className="text-3xl font-bold tracking-tight">MarkItDown Browser</h1>
-          <p className="text-muted-foreground mt-2">
-            Convert documents to Markdown entirely in your browser. No server required.
-          </p>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="p-2.5 rounded-xl bg-primary/10">
+                <svg 
+                  className="w-7 h-7 text-primary" 
+                  fill="none" 
+                  viewBox="0 0 24 24" 
+                  stroke="currentColor" 
+                  strokeWidth={1.5}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+                </svg>
+              </div>
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight">
+                  MarkItDown
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                  Convert documents to Markdown — 100% client-side
+                </p>
+              </div>
+            </div>
+            
+            {/* Dark mode toggle */}
+            <button
+              onClick={() => setDarkMode(!darkMode)}
+              className="p-2.5 rounded-xl bg-muted/50 hover:bg-muted transition-colors"
+              aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {darkMode ? (
+                <svg className="w-5 h-5 text-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />
+                </svg>
+              ) : (
+                <svg className="w-5 h-5 text-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21.752 15.002A9.72 9.72 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
+                </svg>
+              )}
+            </button>
+          </div>
         </div>
       </header>
 
-      <main className="container mx-auto px-4 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <main className="container mx-auto px-4 py-8 flex-1">
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
           {/* Left Panel - Upload and File List */}
-          <div className="space-y-6">
+          <div className="lg:col-span-2 space-y-5">
             <FileUpload onFilesSelected={handleFilesSelected} />
             
             {files.length > 0 && (
@@ -99,53 +153,72 @@ function App() {
           </div>
 
           {/* Right Panel - Preview and Actions */}
-          <div className="space-y-6">
+          <div className="lg:col-span-3">
             {selectedFile?.result ? (
-              <>
+              <div className="space-y-5">
                 <ActionButtons
                   markdown={selectedFile.result.markdown}
                   filename={selectedFile.file.name}
                 />
                 <MarkdownPreview markdown={selectedFile.result.markdown} />
-              </>
+              </div>
             ) : selectedFile?.loading ? (
-              <div className="flex items-center justify-center h-64 border rounded-lg bg-muted/50">
-                <div className="text-center">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-                  <p className="mt-4 text-muted-foreground">Converting...</p>
+              <div className="h-full min-h-[400px] flex items-center justify-center">
+                <div className="text-center p-8 rounded-2xl bg-card border shadow-sm">
+                  <div className="relative w-16 h-16 mx-auto mb-4">
+                    <div className="absolute inset-0 rounded-full border-4 border-primary/20" />
+                    <div className="absolute inset-0 rounded-full border-4 border-primary border-t-transparent animate-spin" />
+                  </div>
+                  <p className="text-muted-foreground font-medium">Converting document...</p>
+                  <p className="text-sm text-muted-foreground/70 mt-1">{selectedFile.file.name}</p>
                 </div>
               </div>
             ) : selectedFile?.error ? (
-              <div className="flex items-center justify-center h-64 border rounded-lg bg-destructive/10">
-                <div className="text-center text-destructive">
-                  <p className="font-semibold">Conversion Failed</p>
-                  <p className="mt-2 text-sm">{selectedFile.error}</p>
+              <div className="h-full min-h-[400px] flex items-center justify-center">
+                <div className="text-center p-8 rounded-2xl bg-destructive/5 border border-destructive/20 shadow-sm max-w-sm">
+                  <div className="w-14 h-14 rounded-full bg-destructive/10 flex items-center justify-center mx-auto mb-4">
+                    <svg className="w-7 h-7 text-destructive" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                    </svg>
+                  </div>
+                  <p className="font-semibold text-destructive">Conversion Failed</p>
+                  <p className="text-sm text-muted-foreground mt-2">{selectedFile.error}</p>
                 </div>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-64 border rounded-lg bg-muted/50">
-                <p className="text-muted-foreground">
-                  Select a file to preview the converted Markdown
-                </p>
+              <div className="h-full min-h-[400px] flex items-center justify-center">
+                <div className="text-center p-8 rounded-2xl bg-card/50 border border-dashed shadow-sm">
+                  <div className="w-16 h-16 rounded-2xl bg-muted flex items-center justify-center mx-auto mb-4">
+                    <svg className="w-8 h-8 text-muted-foreground/50" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m5.231 13.481L15 17.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v16.5c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9zm3.75 11.625a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+                    </svg>
+                  </div>
+                  <p className="text-muted-foreground font-medium">
+                    Select a file to preview
+                  </p>
+                  <p className="text-sm text-muted-foreground/60 mt-1">
+                    Your Markdown will appear here
+                  </p>
+                </div>
               </div>
             )}
           </div>
         </div>
       </main>
 
-      <footer className="border-t mt-auto">
-        <div className="container mx-auto px-4 py-6 text-center text-sm text-muted-foreground">
-          <p>
+      <footer className="border-t bg-card/50">
+        <div className="container mx-auto px-4 py-4 text-center">
+          <p className="text-sm text-muted-foreground">
             Browser-based version of{' '}
             <a
               href="https://github.com/microsoft/markitdown"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline hover:text-foreground"
+              className="text-primary hover:underline font-medium"
             >
               Microsoft MarkItDown
             </a>
-            . All processing happens locally in your browser.
+            
           </p>
         </div>
       </footer>

--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Copy, Download, Check } from 'lucide-react';
 
 interface ActionButtonsProps {
   markdown: string;
@@ -37,29 +36,39 @@ export function ActionButtons({ markdown, filename }: ActionButtonsProps) {
   };
 
   return (
-    <div className="flex gap-2">
+    <div className="flex gap-3">
       <button
         onClick={handleCopy}
-        className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+        className={`flex items-center gap-2.5 px-5 py-2.5 text-sm font-semibold rounded-xl border transition-all duration-200 ${
+          copied
+            ? 'bg-green-500/10 border-green-500/30 text-green-600'
+            : 'border-border bg-card hover:bg-muted hover:border-primary/30 hover:shadow-sm'
+        }`}
       >
         {copied ? (
           <>
-            <Check className="w-4 h-4" />
-            Copied!
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span className="text-green-600">Copied!</span>
           </>
         ) : (
           <>
-            <Copy className="w-4 h-4" />
-            Copy
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+            </svg>
+            Copy Markdown
           </>
         )}
       </button>
 
       <button
         onClick={handleDownload}
-        className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+        className="flex items-center gap-2.5 px-5 py-2.5 text-sm font-semibold rounded-xl border border-transparent bg-primary text-primary-foreground hover:bg-primary/90 hover:shadow-lg transition-all duration-200"
       >
-        <Download className="w-4 h-4" />
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+        </svg>
         Download
       </button>
     </div>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -1,4 +1,4 @@
-import { FileText, X, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import type { DocumentConverterResult } from '../core/types';
 
 interface FileResult {
@@ -19,12 +19,15 @@ export function FileList({ files, selectedIndex, onSelect, onRemove }: FileListP
   if (files.length === 0) return null;
 
   return (
-    <div className="border rounded-lg overflow-hidden">
-      <div className="bg-muted/50 px-4 py-2 border-b">
-        <h3 className="font-medium text-sm">Files ({files.length})</h3>
+    <div className="border rounded-xl overflow-hidden shadow-sm bg-card">
+      <div className="bg-muted/40 px-4 py-3 border-b flex items-center justify-between">
+        <h3 className="font-semibold text-sm">Files ({files.length})</h3>
+        <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded-full">
+          {files.length} {files.length === 1 ? 'file' : 'files'}
+        </span>
       </div>
 
-      <div className="divide-y">
+      <div className="divide-y divide-border/50">
         {files.map((fileResult, index) => {
           const { file, result, error, loading } = fileResult;
           const isSelected = selectedIndex === index;
@@ -32,32 +35,48 @@ export function FileList({ files, selectedIndex, onSelect, onRemove }: FileListP
           return (
             <div
               key={`${file.name}-${index}`}
-              className={`flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors ${
-                isSelected ? 'bg-primary/5' : 'hover:bg-muted/50'
+              className={`flex items-center gap-3 px-4 py-3.5 cursor-pointer transition-all duration-200 ${
+                isSelected 
+                  ? 'bg-primary/8 border-l-2 border-l-primary' 
+                  : 'hover:bg-muted/50 border-l-2 border-l-transparent'
               }`}
               onClick={() => onSelect(index)}
             >
               <div className="flex-shrink-0">
                 {loading ? (
-                  <Loader2 className="w-5 h-5 text-muted-foreground animate-spin" />
+                  <div className="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center">
+                    <Loader2 className="w-5 h-5 text-primary animate-spin" />
+                  </div>
                 ) : error ? (
-                  <AlertCircle className="w-5 h-5 text-destructive" />
+                  <div className="w-9 h-9 rounded-lg bg-destructive/10 flex items-center justify-center">
+                    <svg className="w-5 h-5 text-destructive" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                    </svg>
+                  </div>
                 ) : result ? (
-                  <CheckCircle className="w-5 h-5 text-green-500" />
+                  <div className="w-9 h-9 rounded-lg bg-green-500/10 flex items-center justify-center">
+                    <svg className="w-5 h-5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  </div>
                 ) : (
-                  <FileText className="w-5 h-5 text-muted-foreground" />
+                  <div className="w-9 h-9 rounded-lg bg-muted flex items-center justify-center">
+                    <svg className="w-5 h-5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+                    </svg>
+                  </div>
                 )}
               </div>
 
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium truncate">{file.name}</p>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-muted-foreground mt-0.5">
                   {loading
                     ? 'Converting...'
                     : error
                     ? 'Failed'
                     : result
-                    ? `${result.markdown.length} chars`
+                    ? `${result.markdown.length.toLocaleString()} characters`
                     : 'Pending'}
                 </p>
               </div>
@@ -67,9 +86,11 @@ export function FileList({ files, selectedIndex, onSelect, onRemove }: FileListP
                   e.stopPropagation();
                   onRemove(index);
                 }}
-                className="flex-shrink-0 p-1 rounded hover:bg-muted transition-colors"
+                className="flex-shrink-0 p-2 rounded-lg hover:bg-muted transition-colors opacity-60 hover:opacity-100"
               >
-                <X className="w-4 h-4 text-muted-foreground" />
+                <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
               </button>
             </div>
           );

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react';
-import { Upload, FileText } from 'lucide-react';
 
 interface FileUploadProps {
   onFilesSelected: (files: File[]) => void;
@@ -45,10 +44,10 @@ export function FileUpload({ onFilesSelected }: FileUploadProps) {
 
   return (
     <div
-      className={`relative border-2 border-dashed rounded-lg p-8 text-center transition-colors ${
+      className={`relative group border-2 border-dashed rounded-2xl p-10 text-center transition-all duration-300 ${
         isDragging
-          ? 'border-primary bg-primary/5'
-          : 'border-muted-foreground/25 hover:border-primary/50'
+          ? 'border-primary bg-primary/5 scale-[1.02]'
+          : 'border-border/60 hover:border-primary/40 hover:bg-muted/30'
       }`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
@@ -62,29 +61,41 @@ export function FileUpload({ onFilesSelected }: FileUploadProps) {
         className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
       />
 
-      <div className="flex flex-col items-center gap-4">
-        <div className="p-4 rounded-full bg-muted">
+      <div className="flex flex-col items-center gap-5">
+        <div className={`relative p-5 rounded-2xl transition-all duration-300 ${
+          isDragging 
+            ? 'bg-primary/15 scale-110' 
+            : 'bg-muted group-hover:bg-muted/80'
+        }`}>
           {isDragging ? (
-            <FileText className="w-8 h-8 text-primary" />
+            <svg className="w-10 h-10 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m6.75 12l-3-3m0 0l-3 3m3-3v6m-1.5-9H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+            </svg>
           ) : (
-            <Upload className="w-8 h-8 text-muted-foreground" />
+            <svg className="w-10 h-10 text-muted-foreground/60" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+            </svg>
+          )}
+          {/* Animated ring on drag */}
+          {isDragging && (
+            <div className="absolute inset-0 rounded-2xl animate-pulse bg-primary/20" />
           )}
         </div>
 
         <div>
-          <p className="text-lg font-medium">
+          <p className="text-lg font-semibold text-foreground">
             {isDragging ? 'Drop files here' : 'Drag & drop files here'}
           </p>
-          <p className="text-sm text-muted-foreground mt-1">
+          <p className="text-sm text-muted-foreground mt-1.5">
             or click to browse
           </p>
         </div>
 
-        <div className="flex flex-wrap justify-center gap-2 mt-2">
+        <div className="flex flex-wrap justify-center gap-2 mt-1">
           {['PDF', 'DOCX', 'XLSX', 'PPTX', 'HTML'].map(format => (
             <span
               key={format}
-              className="px-2 py-1 text-xs rounded-full bg-muted text-muted-foreground"
+              className="px-3 py-1.5 text-xs font-medium rounded-full bg-muted/60 text-muted-foreground/80 border border-border/40"
             >
               {format}
             </span>

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -15,14 +15,30 @@ export function MarkdownPreview({ markdown }: MarkdownPreviewProps) {
   const html = marked.parse(markdown) as string;
 
   return (
-    <div className="border rounded-lg overflow-hidden">
-      <div className="bg-muted/50 px-4 py-2 border-b">
-        <h3 className="font-medium text-sm">Preview</h3>
+    <div className="border rounded-xl overflow-hidden shadow-sm bg-card">
+      <div className="bg-muted/40 px-4 py-3 border-b flex items-center justify-between">
+        <h3 className="font-semibold text-sm">Preview</h3>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground bg-muted px-2 py-1 rounded-full">
+            Markdown
+          </span>
+        </div>
       </div>
 
-      <div className="p-4 max-h-[600px] overflow-y-auto">
+      <div className="p-5 max-h-[500px] overflow-y-auto bg-card/50">
         <div
-          className="prose prose-sm max-w-none dark:prose-invert"
+          className="prose prose-sm max-w-none 
+            prose-headings:font-semibold prose-headings:tracking-tight
+            prose-h1:text-xl prose-h2:text-lg prose-h3:text-base
+            prose-p:leading-relaxed prose-p:text-foreground/90
+            prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+            prose-code:bg-muted/80 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-sm
+            prose-pre:bg-muted/60 prose-pre:rounded-lg
+            prose-blockquote:border-l-primary/50 prose-blockquote:bg-muted/30 prose-blockquote:px-4 prose-blockquote:rounded-r-lg
+            prose-li:marker:text-muted-foreground/60
+            prose-img:rounded-lg prose-img:shadow-sm
+            dark:prose-invert
+            prose-primary:text-primary"
           dangerouslySetInnerHTML={{ __html: html }}
         />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -4,48 +4,88 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Modern, elegant green palette - fresh and professional */
+    --background: 150 20% 97%;
+    --foreground: 150 25% 12%;
+    
+    /* Card with subtle warmth */
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 150 25% 12%;
+    
+    /* Popover with slight warmth */
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-    --radius: 0.5rem;
+    --popover-foreground: 150 25% 12%;
+    
+    /* Primary - Rich emerald green */
+    --primary: 150 60% 35%;
+    --primary-foreground: 0 0% 100%;
+    
+    /* Secondary - Soft sage green */
+    --secondary: 150 15% 94%;
+    --secondary-foreground: 150 25% 12%;
+    
+    /* Muted - Soft sage/gray */
+    --muted: 150 10% 92%;
+    --muted-foreground: 150 10% 45%;
+    
+    /* Accent - Vibrant green for highlights */
+    --accent: 150 55% 40%;
+    --accent-foreground: 0 0% 100%;
+    
+    /* Destructive - Soft red */
+    --destructive: 0 70% 55%;
+    --destructive-foreground: 0 0% 100%;
+    
+    /* Border - Subtle warm gray-green */
+    --border: 150 15% 80%;
+    --input: 150 15% 80%;
+    --ring: 150 60% 35%;
+    
+    --radius: 0.75rem;
+    
+    /* Chart colors - green variations */
+    --chart-1: 150 60% 35%;
+    --chart-2: 170 50% 45%;
+    --chart-3: 190 50% 40%;
+    --chart-4: 200 60% 40%;
+    --chart-5: 160 60% 45%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    /* Dark mode - Deep, rich forest green */
+    --background: 150 30% 8%;
+    --foreground: 150 20% 95%;
+    
+    --card: 150 25% 11%;
+    --card-foreground: 150 20% 95%;
+    
+    --popover: 150 25% 11%;
+    --popover-foreground: 150 20% 95%;
+    
+    --primary: 150 55% 45%;
+    --primary-foreground: 150 30% 8%;
+    
+    --secondary: 150 20% 16%;
+    --secondary-foreground: 150 20% 95%;
+    
+    --muted: 150 15% 18%;
+    --muted-foreground: 150 10% 55%;
+    
+    --accent: 150 55% 40%;
+    --accent-foreground: 0 0% 100%;
+    
+    --destructive: 0 70% 55%;
+    --destructive-foreground: 0 0% 100%;
+    
+    --border: 150 15% 22%;
+    --input: 150 15% 22%;
+    --ring: 150 55% 45%;
+    
+    --chart-1: 150 55% 45%;
+    --chart-2: 170 50% 45%;
+    --chart-3: 190 50% 40%;
+    --chart-4: 200 60% 40%;
+    --chart-5: 160 60% 45%;
   }
 }
 
@@ -55,5 +95,10 @@
   }
   body {
     @apply bg-background text-foreground;
+    /* Subtle gradient background - green tint */
+    background-image: 
+      radial-gradient(ellipse at 50% 0%, hsl(var(--primary) / 0.08) 0%, transparent 50%),
+      radial-gradient(ellipse at 100% 100%, hsl(150, 30%, 10%) 0%, transparent 40%);
+    background-attachment: fixed;
   }
 }


### PR DESCRIPTION
- Implement dark mode toggle with system preference detection
- Update color scheme from blue/gray to emerald green palette
- Redesign header with gradient accent and dark mode toggle button
- Enhance file upload component with improved drag-drop animations
- Update file list with custom icon boxes and better styling
- Add sophisticated prose styling for markdown preview
- Improve loading, error, and empty state designs
- Replace lucide-react icons with inline SVGs

BREAKING CHANGE: Dark mode is now enabled by default via JS and applies 'dark' class to document root